### PR TITLE
Refactors Store functions into separate modules

### DIFF
--- a/lib/legacy/api/calls.ex
+++ b/lib/legacy/api/calls.ex
@@ -1,6 +1,9 @@
 defmodule Legacy.Api.Calls do
   use Maru.Router
 
+  alias Legacy.Calls.Store
+  alias Legacy.Calls
+
   helpers Legacy.Api.SharedParams
 
   params do
@@ -15,14 +18,14 @@ defmodule Legacy.Api.Calls do
   post do
     response = case Enum.map([:new, :old], &Map.has_key?(params, &1)) do
       [true, true] ->
-        {new, old} = Legacy.Calls.incr(
+        {new, old} = Store.incr(
           params[:feature_name], params[:ts], {params[:new], params[:old]}
         )
         %{new: new, old: old}
       [false, true] ->
-        %{old: Legacy.Calls.incr_old(params[:feature_name], params[:ts], params[:old])}
+        %{old: Store.incr_old(params[:feature_name], params[:ts], params[:old])}
       [true, false] ->
-        %{new: Legacy.Calls.incr_new(params[:feature_name], params[:ts], params[:new])}
+        %{new: Store.incr_new(params[:feature_name], params[:ts], params[:new])}
     end
 
     conn |> json(%{data: response})
@@ -40,7 +43,7 @@ defmodule Legacy.Api.Calls do
 
     desc "aggregates and returns feature calls"
     get do
-      response = Legacy.Calls.aggregate(
+      response = Calls.aggregate(
         params[:feature_name],
         params |> Map.drop([:feature_name]) |> Map.to_list()
       )

--- a/lib/legacy/api/features.ex
+++ b/lib/legacy/api/features.ex
@@ -11,7 +11,7 @@ defmodule Legacy.Api.Features do
 
   desc "creates a new feature"
   post do
-    if Legacy.Features.exists(params[:feature_name]) do
+    if Legacy.Features.Store.exists(params[:feature_name]) do
       conn
       |> put_status(409)
       |> json(%{ errors: ["A Feature with this name already exists."] })
@@ -23,7 +23,7 @@ defmodule Legacy.Api.Features do
 
       conn
       |> put_status(201)
-      |> json(%{data: Legacy.Features.show params[:feature_name]})
+      |> json(%{data: Legacy.Features.Store.show params[:feature_name]})
     end
   end
 
@@ -34,7 +34,7 @@ defmodule Legacy.Api.Features do
 
     desc "gets the feature with the given name"
     get do
-      feature = Legacy.Features.show params[:feature_name]
+      feature = Legacy.Features.Store.show params[:feature_name]
 
       case feature do
         nil -> put_status conn, 404

--- a/lib/legacy/calls.ex
+++ b/lib/legacy/calls.ex
@@ -1,91 +1,12 @@
 defmodule Legacy.Calls do
   @moduledoc """
-  Interface for storing and incrementing feature calls. Each call is assigned
-  to a feature and can be a "new" or an "old" call.
-
-  Currently, calls are aggregated by Day only.
-
-  ### Data Model
-
-  Calls are stored in Redis with arbitrary granularity, down to the second.
-  They are stored in the keyset:
-
-    `calls:<feature_name>:<second_granularity>:<base_timestamp>:<[new|old]>`
-
-  For example, a counter that aggregates calls for the day of Oct 1st, 2017
-  would be represented by a `second_granularity` of `86400000` and a
-  `base_timestamp` of 1506816000000. Thus, it would be stored at the key:
-
-    `calls:<feature_name>:86400000:1506816000000:<[new|old]>`
-
-  The next day would logically be accessible at the same `second_granularity`,
-  with the `base_timestamp` incremented by said granularity.
+  Interface for high-level operations with Calls data. Aggregations and new/old
+  comparative analysis over time can be found here.
   """
 
+  alias Legacy.Calls.Store
   alias Utils.GranularTime
-
-  @doc """
-  Increments both old an new call counts for feature `feature_name` by the given
-  values. All calls will be aggregated according to `timestamp`.
-
-  The new values are returned.
-
-  ## Parameters
-
-    - feature_name: The calls' feature name.
-    - timestamp: The timestamp with which to aggregate the call increments.
-    - new: How much to increment the new calls.
-    - old: How much to increment the old calls.
-  """
-  @spec incr(String.t, non_neg_integer, {integer, integer}) :: {integer, integer}
-  def incr(feature_name, timestamp, { new, old }) do
-    {:ok, redis} = redis_connection()
-    key = call_key feature_name, timestamp, :day
-
-    now_new = Redix.command! redis, ~w(INCRBY #{key}:new #{new})
-    now_old = Redix.command! redis, ~w(INCRBY #{key}:old #{old})
-
-    {now_new, now_old}
-  end
-
-  @doc """
-  Increments the old count for feature `feature_name` by `count`, defaulting to
-  1.
-  """
-  @spec incr_old(String.t, non_neg_integer, integer) :: integer
-  def incr_old(feature_name, timestamp, count \\ 1) do
-    {:ok, redis} = redis_connection()
-    key = call_key feature_name, timestamp, :day
-
-    Redix.command! redis, ~w(INCRBY #{key}:old #{count})
-  end
-
-  @doc """
-  Increments the new count for feature `feature_name` by `count`, defaulting to
-  1.
-  """
-  @spec incr_new(String.t, non_neg_integer, integer) :: integer
-  def incr_new(feature_name, timestamp, count \\ 1) do
-    {:ok, redis} = redis_connection()
-    key = call_key feature_name, timestamp, :day
-
-    Redix.command! redis, ~w(INCRBY #{key}:new #{count})
-  end
-
-  @doc """
-  Retrieves the calls stored for a feature at a specified `timestamp`. In
-  absense of a particular counter, 0 is returned.
-  """
-  @spec get(String.t, non_neg_integer) :: {integer, integer}
-  def get(feature_name, timestamp) do
-    {:ok, redis} = redis_connection()
-    key = call_key feature_name, timestamp, :day
-
-    {
-      int_or_0(Redix.command! redis, ~w(GET #{key}:new)),
-      int_or_0(Redix.command! redis, ~w(GET #{key}:old))
-    }
-  end
+  alias Utils.Reducers
 
   @doc """
   Generates a calls timeseries for a feature, from the given `from` timestamp
@@ -96,10 +17,10 @@ defmodule Legacy.Calls do
     # TODO: Limit from -> to range, otherwise it's possible to DoS server
     to = to || DateTime.to_unix(DateTime.utc_now)
     timestamps = GranularTime.normalized_ts_range(from, to)
-    calls = get_multiple_calls(feature_name, timestamps)
+    calls = Store.get_many(feature_name, timestamps)
 
     calls
-    |> Enum.reduce(%{ts: [], new: [], old: []}, fn ([new, old], acc) ->
+    |> Enum.reduce(%{ts: [], new: [], old: []}, fn {new, old}, acc ->
       acc
       |> Map.update!(:new, fn lst -> [new | lst] end)
       |> Map.update!(:old, fn lst -> [old | lst] end)
@@ -149,7 +70,7 @@ defmodule Legacy.Calls do
     seconds_period_size = period_size * GranularTime.int_granularity(period_granularity)
     bucket_size = div seconds_period_size, GranularTime.int_granularity(:day)
 
-    get_multiple_calls(feature_name, calls_timestamps)
+    Store.get_many(feature_name, calls_timestamps)
     |> bucketize_calls(bucket_size)
     |> aggregate_buckets(aggregation)
     |> Map.put(:ts, aggregate_ts)
@@ -178,7 +99,7 @@ defmodule Legacy.Calls do
     # TODO: stop double-reverse (in aggregation and here)
     analysis = Keyword.get opts, :analysis, :rate
 
-    aggregated = aggregate(feature_name, Keyword.drop(opts, [:analysis]))
+    aggregated = aggregate(feature_name, Keyword.drop(opts, [:analysis, :rolling]))
 
     analysed = analyse(aggregated[:new], aggregated[:old], analysis)
 
@@ -219,48 +140,16 @@ defmodule Legacy.Calls do
 
   defp aggregate_buckets(call_buckets, aggregation) when aggregation in [:sum, :avg] do
     call_buckets
-    |> Map.update!(:new, &Enum.map(&1, fn bucket -> apply(Utils.Reducers, aggregation, [bucket]) end))
-    |> Map.update!(:old, &Enum.map(&1, fn bucket -> apply(Utils.Reducers, aggregation, [bucket]) end))
+    |> Map.update!(:new, &Enum.map(&1, fn bucket -> apply(Reducers, aggregation, [bucket]) end))
+    |> Map.update!(:old, &Enum.map(&1, fn bucket -> apply(Reducers, aggregation, [bucket]) end))
   end
-
-  @doc """
-  Grabs calls from redis for the given feature and list of timestamps. Results
-  are returned as an enumerable of [new_count, old_count] pairs.
-  """
-  @spec get_multiple_calls(String.t, [non_neg_integer]) :: Stream.t
-  defp get_multiple_calls(_, []), do: []
-  defp get_multiple_calls(feature_name, timestamps) do
-    {:ok, redis} = redis_connection()
-
-    keys = timestamps
-    |> Stream.map(fn ts -> call_key(feature_name, ts, :day) end)
-    |> Stream.flat_map(fn key -> [key <> ":new", key <> ":old"] end)
-    |> Enum.join(" ")
-
-    Redix.command!(redis, ~w(MGET #{keys}))
-    |> Stream.map(&int_or_0(&1))
-    |> Stream.chunk(2)
-  end
-
-  defp redis_connection do
-    Redix.start_link "redis://localhost/15"
-  end
-
-  defp call_key(feature_name, timestamp, granularity) do
-    ts = GranularTime.base_ts timestamp, granularity
-    int_gran = GranularTime.int_granularity granularity
-    "calls:#{feature_name}:#{int_gran}:#{ts}"
-  end
-
-  defp int_or_0(nil), do: 0
-  defp int_or_0(val), do: String.to_integer val
 
   # Zips enumerables into 2 lists. Does not respect original order. Do a reverse
   # on each if that's important.
   defp zip_to_list([]), do: []
   defp zip_to_list(enum), do: zip_to_list([[], []], enum)
   defp zip_to_list(acc, []), do: acc
-  defp zip_to_list([left, right], [[first | [last | []]] | tail]) do
+  defp zip_to_list([left, right], [{first, last} | tail]) do
     zip_to_list [[first | left], [last | right]], tail
   end
 end

--- a/lib/legacy/calls/Store.ex
+++ b/lib/legacy/calls/Store.ex
@@ -1,0 +1,117 @@
+defmodule Legacy.Calls.Store do
+  @moduledoc """
+  Interface for storing and incrementing feature calls. Each call is assigned
+  to a feature and can be a "new" or an "old" call.
+
+  Currently, calls are aggregated by Day only.
+
+  ### Data Model
+
+  Calls are stored in Redis with arbitrary granularity, down to the second.
+  They are stored in the keyset:
+
+    `calls:<feature_name>:<second_granularity>:<base_timestamp>:<[new|old]>`
+
+  For example, a counter that aggregates calls for the day of Oct 1st, 2017
+  would be represented by a `second_granularity` of `86400000` and a
+  `base_timestamp` of 1506816000000. Thus, it would be stored at the key:
+
+    `calls:<feature_name>:86400000:1506816000000:<[new|old]>`
+
+  The next day would logically be accessible at the same `second_granularity`,
+  with the `base_timestamp` incremented by said granularity.
+  """
+
+  import Legacy.Redis
+
+  alias Utils.GranularTime
+
+  @doc """
+  Increments both old an new call counts for feature `feature_name` by the given
+  values. All calls will be aggregated according to `timestamp`.
+
+  The new values are returned.
+
+  ## Parameters
+
+    - feature_name: The calls' feature name.
+    - timestamp: The timestamp with which to aggregate the call increments.
+    - new: How much to increment the new calls.
+    - old: How much to increment the old calls.
+  """
+  @spec incr(String.t, non_neg_integer, {integer, integer}) :: {integer, integer}
+  def incr(feature_name, timestamp, { new, old }) do
+    {:ok, redis} = redis_connection()
+    key = call_key feature_name, timestamp, :day
+
+    now_new = Redix.command! redis, ~w(INCRBY #{key}:new #{new})
+    now_old = Redix.command! redis, ~w(INCRBY #{key}:old #{old})
+
+    {now_new, now_old}
+  end
+
+  @doc """
+  Increments the old count for feature `feature_name` by `count`, defaulting to
+  1.
+  """
+  @spec incr_old(String.t, non_neg_integer, integer) :: integer
+  def incr_old(feature_name, timestamp, count \\ 1) do
+    {:ok, redis} = redis_connection()
+    key = call_key feature_name, timestamp, :day
+
+    Redix.command! redis, ~w(INCRBY #{key}:old #{count})
+  end
+
+  @doc """
+  Increments the new count for feature `feature_name` by `count`, defaulting to
+  1.
+  """
+  @spec incr_new(String.t, non_neg_integer, integer) :: integer
+  def incr_new(feature_name, timestamp, count \\ 1) do
+    {:ok, redis} = redis_connection()
+    key = call_key feature_name, timestamp, :day
+
+    Redix.command! redis, ~w(INCRBY #{key}:new #{count})
+  end
+
+  @doc """
+  Retrieves the calls stored for a feature at a specified `timestamp`. In
+  absense of a particular counter, 0 is returned.
+  """
+  @spec get(String.t, non_neg_integer) :: {integer, integer}
+  def get(feature_name, timestamp) do
+    {:ok, redis} = redis_connection()
+    key = call_key feature_name, timestamp, :day
+
+    {
+      int_or_0(Redix.command! redis, ~w(GET #{key}:new)),
+      int_or_0(Redix.command! redis, ~w(GET #{key}:old))
+    }
+  end
+
+  @doc """
+  Grabs calls from redis for the given feature and list of timestamps. Results
+  are returned as an enumerable of {new_count, old_count} pairs.
+  """
+  @spec get_many(String.t, [non_neg_integer]) :: [{non_neg_integer, non_neg_integer}]
+  def get_many(_, []), do: []
+  def get_many(feature_name, timestamps) do
+    {:ok, redis} = redis_connection()
+
+    keys = timestamps
+    |> Stream.map(fn ts -> call_key(feature_name, ts, :day) end)
+    |> Stream.flat_map(fn key -> [key <> ":new", key <> ":old"] end)
+    |> Enum.join(" ")
+
+    Redix.command!(redis, ~w(MGET #{keys}))
+    |> Stream.map(&int_or_0(&1))
+    |> Stream.chunk(2)
+    |> Enum.map(fn [new | [old | []]] -> {new, old} end)
+  end
+
+  defp call_key(feature_name, timestamp, granularity) do
+    ts = GranularTime.base_ts timestamp, granularity
+    int_gran = GranularTime.int_granularity granularity
+    "calls:#{feature_name}:#{int_gran}:#{ts}"
+  end
+end

--- a/lib/legacy/features.ex
+++ b/lib/legacy/features.ex
@@ -1,8 +1,9 @@
 defmodule Legacy.Features do
   @moduledoc """
-  Provides a CRUD interface for Features. These are identified by a unique name
-  and store such information as their expiry periods and create/update dates.
+  Helpers for complex operations involving updating and reading Features.
   """
+
+  alias Legacy.Features.Store
 
   @doc """
   Initialize a feature structure if it doesn't exist, update it with `opts` if
@@ -10,83 +11,12 @@ defmodule Legacy.Features do
   """
   def init(name, opts \\ []) do
     defaults = feature_defaults name
-    init_defaults name, Keyword.drop(defaults, Keyword.keys(opts))
-    update name, opts
-  end
-
-  @doc """
-  Update an existing feature. Updates only the given attributes in `opts`.
-  """
-  def update(_name, []), do: nil
-  def update(name, opts) do
-    {:ok, redis} = redis_connection()
-    params = Enum.map(opts, fn { key, value } -> "#{key} #{value}" end)
-      |> Enum.join(" ")
-
-    Redix.command! redis, ~w(HMSET #{feature_key(name)} #{params})
-  end
-
-  @doc """
-  Returns whether a feature with the given `name` already exists.
-  """
-  def exists(name) do
-    {:ok, redis} = redis_connection()
-    Redix.command!(redis, ~w(EXISTS #{feature_key(name)})) == 1
-  end
-
-  @doc """
-  Returns the current config for a feature with the given `name` or nil if it
-  doesn't exist.
-  """
-  def show(name) do
-    {:ok, redis} = redis_connection()
-
-    case Redix.command! redis, ~w(HGETALL #{feature_key(name)}) do
-      [] -> nil
-      values ->
-        Stream.chunk(values, 2)
-        |> Enum.reduce(%{ }, fn ([key, value], map) ->
-          atom_key = String.to_atom(key)
-          Map.put(map, atom_key, fix_value_type(atom_key, value))
-        end)
-    end
-  end
-
-  defp init_defaults(_name, []), do: nil
-  defp init_defaults(name, defaults) do
-    {:ok, redis} = redis_connection()
-    redis_key = feature_key name
-
-    Enum.map defaults, fn { key, value } ->
-      # TODO: optimize this into pipeline
-      Redix.command! redis, ~w(HSETNX #{redis_key} #{key} #{value})
-    end
+    Store.set_missing name, Keyword.drop(defaults, Keyword.keys(opts))
+    Store.update name, opts
   end
 
   defp feature_defaults(name) do
     now = DateTime.to_iso8601 DateTime.utc_now
     [description: name, expire_period: 30, created_at: now, updated_at: now]
-  end
-
-  defp redis_connection do
-    Redix.start_link "redis://localhost/15"
-  end
-
-  defp feature_key(name) do
-    "features:#{name}"
-  end
-
-  defp fix_value_type(:expire_period, value) do
-    elem(Integer.parse(value), 0)
-  end
-  defp fix_value_type(:created_at, value), do: fix_date_value(value)
-  defp fix_value_type(:updated_at, value), do: fix_date_value(value)
-  defp fix_value_type(_, value), do: value
-
-  defp fix_date_value(date_string) do
-    case DateTime.from_iso8601(date_string) do
-      {:ok, date, _offset} -> date
-      {:error, err} -> raise "Bad date format. Got #{date_string}, error: #{err}"
-    end
   end
 end

--- a/lib/legacy/features/store.ex
+++ b/lib/legacy/features/store.ex
@@ -1,0 +1,80 @@
+defmodule Legacy.Features.Store do
+  @moduledoc """
+  Provides a CRUD interface for Features. These are identified by a unique name
+  and store such information as their expiry periods and create/update dates.
+  """
+
+  import Legacy.Redis
+
+  @doc """
+  Update an existing feature. Updates only the given attributes in `opts`.
+  """
+  @spec update(String.t, [{String.t, any}]) :: String.t
+  def update(_name, []), do: nil
+  def update(name, opts) do
+    {:ok, redis} = redis_connection()
+
+    params = Enum.flat_map(opts, fn { key, value } -> [key, value] end)
+    command = ["HMSET" | [feature_key(name) | params]]
+
+    Redix.command! redis, command
+  end
+
+  @doc """
+  Sets the given values, if they are not set yet. Use this to ensure some
+  defaults in the Feature.
+  """
+  @spec set_missing(String.t, [{String.t, any}]) :: [String.t]
+  def set_missing(_name, []), do: nil
+  def set_missing(name, values) do
+    {:ok, redis} = redis_connection()
+    redis_key = feature_key name
+
+    Enum.map values, fn { key, value } ->
+      # TODO: optimize this into pipeline
+      Redix.command! redis, ["HSETNX", redis_key, key, value]
+    end
+  end
+
+  @doc """
+  Returns whether a feature with the given `name` already exists.
+  """
+  @spec exists(String.t) :: boolean
+  def exists(name) do
+    {:ok, redis} = redis_connection()
+    Redix.command!(redis, ~w(EXISTS #{feature_key(name)})) == 1
+  end
+
+  @doc """
+  Returns the current config for a feature with the given `name` or nil if it
+  doesn't exist.
+  """
+  @spec show(String.t) :: Map.t
+  def show(name) do
+    {:ok, redis} = redis_connection()
+
+    case Redix.command! redis, ~w(HGETALL #{feature_key(name)}) do
+      [] -> nil
+      values ->
+        Stream.chunk(values, 2)
+        |> Enum.reduce(%{}, fn ([key, value], map) ->
+          atom_key = String.to_atom(key)
+          Map.put(map, atom_key, fix_value_type(atom_key, value))
+        end)
+    end
+  end
+
+  defp feature_key(name), do: "features:#{name}"
+
+  defp fix_value_type(:expire_period, value), do: elem(Integer.parse(value), 0)
+  defp fix_value_type(:created_at, value), do: fix_date_value(value)
+  defp fix_value_type(:updated_at, value), do: fix_date_value(value)
+  defp fix_value_type(_, value), do: value
+
+  defp fix_date_value(date_string) do
+    case DateTime.from_iso8601(date_string) do
+      {:ok, date, _offset} -> date
+      {:error, err} -> raise "Bad date format. Got #{date_string}, error: #{err}"
+    end
+  end
+end

--- a/lib/legacy/redis.ex
+++ b/lib/legacy/redis.ex
@@ -1,0 +1,8 @@
+defmodule Legacy.Redis do
+  def redis_connection do
+    Redix.start_link "redis://localhost/15"
+  end
+
+  def int_or_0(nil), do: 0
+  def int_or_0(val), do: String.to_integer val
+end

--- a/test/legacy/api/calls_test.exs
+++ b/test/legacy/api/calls_test.exs
@@ -16,7 +16,7 @@ defmodule Legacy.Api.CallsTest do
     test "increments calls for the given timestamp" do
       post_body "/", %{feature_name: "ft-api-call-2", new: 5, old: 2, ts: 1483228799000}
 
-      assert Legacy.Calls.get("ft-api-call-2", 1483228799) == {5, 2}
+      assert Legacy.Calls.Store.get("ft-api-call-2", 1483228799) == {5, 2}
     end
 
     test "it increments and returns single calls" do
@@ -28,7 +28,7 @@ defmodule Legacy.Api.CallsTest do
         post_body "/", %{feature_name: "ft-api-call-3", old: 12, ts: 1483228799000}
       ) == %{"data" => %{"old" => 12}}
 
-      assert Legacy.Calls.get("ft-api-call-3", 1483228799) == {18, 12}
+      assert Legacy.Calls.Store.get("ft-api-call-3", 1483228799) == {18, 12}
     end
 
     test "validates needed parameters" do
@@ -64,10 +64,10 @@ defmodule Legacy.Api.CallsTest do
 
     test "returns the requested amount of data with values, when they exist" do
       now = DateTime.to_unix DateTime.utc_now
-      Legacy.Calls.incr("ft-api-call-5", now, {1, 3})
-      Legacy.Calls.incr("ft-api-call-5", now - 86400, {2, 2})
-      Legacy.Calls.incr("ft-api-call-5", now - 7 * 86400, {3, 1})
-      Legacy.Calls.incr("ft-api-call-5", now - 8 * 86400, {4, 2})
+      Legacy.Calls.Store.incr("ft-api-call-5", now, {1, 3})
+      Legacy.Calls.Store.incr("ft-api-call-5", now - 86400, {2, 2})
+      Legacy.Calls.Store.incr("ft-api-call-5", now - 7 * 86400, {3, 1})
+      Legacy.Calls.Store.incr("ft-api-call-5", now - 8 * 86400, {4, 2})
 
       url = "aggregate?feature_name=ft-api-call-5&period_granularity=week&periods=2&from=#{now}"
       json = json_response(get url)
@@ -94,7 +94,7 @@ defmodule Legacy.Api.NestedCallsTest do
 
       assert res.status == 200
       assert json_response(res) == %{"data" => %{"new" => 2, "old" => 5}}
-      assert Legacy.Calls.get("ft-api-call-4", 1483228799) == {2, 5}
+      assert Legacy.Calls.Store.get("ft-api-call-4", 1483228799) == {2, 5}
     end
   end
 end

--- a/test/legacy/api/features_test.exs
+++ b/test/legacy/api/features_test.exs
@@ -38,7 +38,7 @@ defmodule Legacy.Api.FeaturesTest do
     test "creates a new feature with the given name & settings" do
       post_body "/", %{feature_name: 'ft-api-feat-3', expire_period: 45}
 
-      feature = Legacy.Features.show 'ft-api-feat-3'
+      feature = Legacy.Features.Store.show 'ft-api-feat-3'
       assert feature
       assert feature[:expire_period] == 45
       assert feature[:description] == "ft-api-feat-3"

--- a/test/legacy/calls/store_test.exs
+++ b/test/legacy/calls/store_test.exs
@@ -1,0 +1,130 @@
+defmodule Legacy.Calls.StoreTest do
+  use Legacy.RedisCase, async: true
+
+  describe "Legacy.Calls.Store.incr/3" do
+    test "creates counters for new & old at the timestamp's base, with day granularity", %{redis: redis} do
+      now = DateTime.to_unix DateTime.utc_now
+      base = div(now, 86400) * 86400
+
+      Legacy.Calls.Store.incr "call-store-1", now , {2, 3}
+
+      assert Redix.command!(redis, ~w(EXISTS calls:call-store-1:86400:#{base}:new)) == 1
+      assert Redix.command!(redis, ~w(EXISTS calls:call-store-1:86400:#{base}:old)) == 1
+    end
+
+    test "sets both new and old counts to values provided", %{redis: redis} do
+      Legacy.Calls.Store.incr "call-store-2", 1506816000, {2, 3}
+
+      new_key = "calls:call-store-2:86400:1506816000:new"
+      old_key = "calls:call-store-2:86400:1506816000:old"
+      assert Redix.command!(redis, ~w(MGET #{new_key} #{old_key})) == ["2", "3"]
+    end
+
+    test "increments by values if counts existed before", %{redis: redis} do
+      new_key = "calls:call-store-3:86400:1506816000:new"
+      old_key = "calls:call-store-3:86400:1506816000:old"
+      Redix.command! redis, ~w(MSET #{new_key} 2 #{old_key} 3)
+
+      Legacy.Calls.Store.incr "call-store-3", 1506816000, {3, 4}
+
+      assert Redix.command!(redis, ~w(MGET #{new_key} #{old_key})) == ["5", "7"]
+    end
+
+    test "returns the new values" do
+      assert Legacy.Calls.Store.incr("call-store-12", 1506816000, {2, 3}) == {2, 3}
+    end
+  end
+
+  describe "Legacy.Calls.Store.incr_new" do
+    test "creates counters for new at the timestamp's base, with day granularity", %{redis: redis} do
+      now = DateTime.to_unix DateTime.utc_now
+      base = div(now, 86400) * 86400
+
+      Legacy.Calls.Store.incr_new "call-store-4", now, 2
+
+      assert Redix.command!(redis, ~w(EXISTS calls:call-store-4:86400:#{base}:new)) == 1
+    end
+
+    test "sets new count to the value provided", %{redis: redis} do
+      Legacy.Calls.Store.incr_new "call-store-5", 1506816000, 2
+      assert Redix.command!(redis, ~w(GET calls:call-store-5:86400:1506816000:new)) == "2"
+    end
+
+    test "increments by value if count existed before", %{redis: redis} do
+      Redix.command! redis, ~w(SET calls:call-store-6:86400:1506816000:new 2)
+
+      Legacy.Calls.Store.incr_new "call-store-6", 1506816000, 3
+
+      assert Redix.command!(redis, ~w(GET calls:call-store-6:86400:1506816000:new)) == "5"
+    end
+
+    test "defauts to value 1 when given none", %{redis: redis} do
+      Legacy.Calls.Store.incr_new "call-store-7", 1506816000
+      assert Redix.command!(redis, ~w(GET calls:call-store-7:86400:1506816000:new)) == "1"
+    end
+
+    test "returns the new value" do
+      assert Legacy.Calls.Store.incr_new("call-store-13", 1506816000, 80) == 80
+    end
+  end
+
+  describe "Legacy.Calls.Store.incr_old" do
+    test "creates counters for old at the timestamp's base, with day granularity", %{redis: redis} do
+      now = DateTime.to_unix DateTime.utc_now
+      base = div(now, 86400) * 86400
+
+      Legacy.Calls.Store.incr_old "call-store-8", now, 2
+
+      assert Redix.command!(redis, ~w(EXISTS calls:call-store-8:86400:#{base}:old)) == 1
+    end
+
+    test "sets old count to the value provided", %{redis: redis} do
+      Legacy.Calls.Store.incr_old "call-store-9", 1506816000, 2
+      assert Redix.command!(redis, ~w(GET calls:call-store-9:86400:1506816000:old)) == "2"
+    end
+
+    test "increments by value if count existed before", %{redis: redis} do
+      Redix.command! redis, ~w(SET calls:call-store-10:86400:1506816000:old 2)
+
+      Legacy.Calls.Store.incr_old "call-store-10", 1506816000, 3
+
+      assert Redix.command!(redis, ~w(GET calls:call-store-10:86400:1506816000:old)) == "5"
+    end
+
+    test "defauts to value 1 when given none", %{redis: redis} do
+      Legacy.Calls.Store.incr_old "call-store-11", 1506816000
+      assert Redix.command!(redis, ~w(GET calls:call-store-11:86400:1506816000:old)) == "1"
+    end
+
+    test "returns the new value" do
+      assert Legacy.Calls.Store.incr_old("call-store-14", 1506816000, 77) == 77
+    end
+  end
+
+  describe "Legacy.Calls.Store.get" do
+    test "returns 0 for both calls when they're missing" do
+      assert Legacy.Calls.Store.get("inexistent", 1506816000) == {0, 0}
+    end
+
+    test "returns a tuple with new and old calls for the given timestamp & feature", %{redis: redis} do
+      Redix.command! redis, ~w(SET calls:call-store-15:86400:1506816000:new 3)
+      Redix.command! redis, ~w(SET calls:call-store-15:86400:1506816000:old 2)
+
+      assert Legacy.Calls.Store.get("call-store-15", 1506816000) == {3, 2}
+    end
+  end
+
+  describe "Legacy.Calls.Store.get_many" do
+    test "returns calls for multiple timestamps", %{redis: redis} do
+      Redix.command! redis, ~w(SET calls:call-store-16:86400:1506816000:new 3)
+      Redix.command! redis, ~w(SET calls:call-store-16:86400:1506902400:old 2)
+      Redix.command! redis, ~w(SET calls:call-store-16:86400:1506988800:old 1)
+
+      assert Legacy.Calls.Store.get_many("call-store-16", [1506816000, 1506902400, 1506988800]) == [
+        {3, 0},
+        {0, 2},
+        {0, 1}
+      ]
+    end
+  end
+end

--- a/test/legacy/calls_test.exs
+++ b/test/legacy/calls_test.exs
@@ -4,117 +4,17 @@ defmodule Legacy.CallsTest do
   setup_all do
     now = DateTime.to_unix DateTime.utc_now
 
-    Legacy.Calls.incr("call-16", now, {5, 5}) # now
-    Legacy.Calls.incr("call-16", now - 86400, {2, 3}) # 1 day
-    Legacy.Calls.incr("call-16", now - 2 * 86400, {4, 3}) # 2 day
-    Legacy.Calls.incr("call-16", now - 3 * 86400, {1, 4}) # 3 day
-    Legacy.Calls.incr("call-16", now - 2592000, {5, 4}) # 1 month
-    Legacy.Calls.incr("call-16", now - 86400 - 2592000, {2, 4}) # 1 month & 1 day
-    Legacy.Calls.incr("call-16", now - 2 * 2592000, {1, 1}) # 2 month
-    Legacy.Calls.incr("call-16", now - 86400 - 2 * 2592000, {3, 1}) # 2 month & 1 day
-    Legacy.Calls.incr("call-16", now - 2 * 86400 - 2 * 2592000, {3, 3}) # 2 month & 2 day
+    Legacy.Calls.Store.incr("call-2", now, {5, 5}) # now
+    Legacy.Calls.Store.incr("call-2", now - 86400, {2, 3}) # 1 day
+    Legacy.Calls.Store.incr("call-2", now - 2 * 86400, {4, 3}) # 2 day
+    Legacy.Calls.Store.incr("call-2", now - 3 * 86400, {1, 4}) # 3 day
+    Legacy.Calls.Store.incr("call-2", now - 2592000, {5, 4}) # 1 month
+    Legacy.Calls.Store.incr("call-2", now - 86400 - 2592000, {2, 4}) # 1 month & 1 day
+    Legacy.Calls.Store.incr("call-2", now - 2 * 2592000, {1, 1}) # 2 month
+    Legacy.Calls.Store.incr("call-2", now - 86400 - 2 * 2592000, {3, 1}) # 2 month & 1 day
+    Legacy.Calls.Store.incr("call-2", now - 2 * 86400 - 2 * 2592000, {3, 3}) # 2 month & 2 day
 
     {:ok, now: now}
-  end
-
-  describe "Legacy.Calls.incr/3" do
-    test "creates counters for new & old at the timestamp's base, with day granularity", %{redis: redis} do
-      now = DateTime.to_unix DateTime.utc_now
-      base = div(now, 86400) * 86400
-
-      Legacy.Calls.incr "call-1", now , {2, 3}
-
-      assert Redix.command!(redis, ~w(EXISTS calls:call-1:86400:#{base}:new)) == 1
-      assert Redix.command!(redis, ~w(EXISTS calls:call-1:86400:#{base}:old)) == 1
-    end
-
-    test "sets both new and old counts to values provided", %{redis: redis} do
-      Legacy.Calls.incr "call-2", 1506816000, {2, 3}
-
-      new_key = "calls:call-2:86400:1506816000:new"
-      old_key = "calls:call-2:86400:1506816000:old"
-      assert Redix.command!(redis, ~w(MGET #{new_key} #{old_key})) == ["2", "3"]
-    end
-
-    test "increments by values if counts existed before", %{redis: redis} do
-      new_key = "calls:call-3:86400:1506816000:new"
-      old_key = "calls:call-3:86400:1506816000:old"
-      Redix.command! redis, ~w(MSET #{new_key} 2 #{old_key} 3)
-
-      Legacy.Calls.incr "call-3", 1506816000, {3, 4}
-
-      assert Redix.command!(redis, ~w(MGET #{new_key} #{old_key})) == ["5", "7"]
-    end
-
-    test "returns the new values" do
-      assert Legacy.Calls.incr("call-12", 1506816000, {2, 3}) == {2, 3}
-    end
-  end
-
-  describe "Legacy.Calls.incr_new" do
-    test "creates counters for new at the timestamp's base, with day granularity", %{redis: redis} do
-      now = DateTime.to_unix DateTime.utc_now
-      base = div(now, 86400) * 86400
-
-      Legacy.Calls.incr_new "call-4", now, 2
-
-      assert Redix.command!(redis, ~w(EXISTS calls:call-4:86400:#{base}:new)) == 1
-    end
-
-    test "sets new count to the value provided", %{redis: redis} do
-      Legacy.Calls.incr_new "call-5", 1506816000, 2
-      assert Redix.command!(redis, ~w(GET calls:call-5:86400:1506816000:new)) == "2"
-    end
-
-    test "increments by value if count existed before", %{redis: redis} do
-      Redix.command! redis, ~w(SET calls:call-6:86400:1506816000:new 2)
-
-      Legacy.Calls.incr_new "call-6", 1506816000, 3
-
-      assert Redix.command!(redis, ~w(GET calls:call-6:86400:1506816000:new)) == "5"
-    end
-
-    test "defauts to value 1 when given none", %{redis: redis} do
-      Legacy.Calls.incr_new "call-7", 1506816000
-      assert Redix.command!(redis, ~w(GET calls:call-7:86400:1506816000:new)) == "1"
-    end
-
-    test "returns the new value" do
-      assert Legacy.Calls.incr_new("call-13", 1506816000, 80) == 80
-    end
-  end
-
-  describe "Legacy.Calls.incr_old" do
-    test "creates counters for old at the timestamp's base, with day granularity", %{redis: redis} do
-      now = DateTime.to_unix DateTime.utc_now
-      base = div(now, 86400) * 86400
-
-      Legacy.Calls.incr_old "call-8", now, 2
-
-      assert Redix.command!(redis, ~w(EXISTS calls:call-8:86400:#{base}:old)) == 1
-    end
-
-    test "sets old count to the value provided", %{redis: redis} do
-      Legacy.Calls.incr_old "call-9", 1506816000, 2
-      assert Redix.command!(redis, ~w(GET calls:call-9:86400:1506816000:old)) == "2"
-    end
-
-    test "increments by value if count existed before", %{redis: redis} do
-      Redix.command! redis, ~w(SET calls:call-10:86400:1506816000:old 2)
-
-      Legacy.Calls.incr_old "call-10", 1506816000, 3
-
-      assert Redix.command!(redis, ~w(GET calls:call-10:86400:1506816000:old)) == "5"
-    end
-
-    test "defauts to value 1 when given none", %{redis: redis} do
-      Legacy.Calls.incr_old "call-11", 1506816000
-      assert Redix.command!(redis, ~w(GET calls:call-11:86400:1506816000:old)) == "1"
-    end
-
-    test "returns the new value" do
-      assert Legacy.Calls.incr_old("call-14", 1506816000, 77) == 77
-    end
   end
 
   describe "Legacy.Calls.timeseries" do
@@ -141,12 +41,12 @@ defmodule Legacy.CallsTest do
         {1490572800, "old", 2}, {1490572800, "new", 6},
         {1490659200, "new", 8}
       ]
-      |> Stream.map(fn {ts, kind, count} -> "calls:call-15:86400:#{ts}:#{kind} #{count}" end)
+      |> Stream.map(fn {ts, kind, count} -> "calls:call-1:86400:#{ts}:#{kind} #{count}" end)
       |> Enum.join(" ")
 
       Redix.command! redis, ~w(MSET #{sets})
 
-      assert Legacy.Calls.timeseries("call-15", 1490397264, 1490742836) == %{
+      assert Legacy.Calls.timeseries("call-1", 1490397264, 1490742836) == %{
         ts: [1490400000, 1490486400, 1490572800, 1490659200],
         new: [0, 3, 6, 8],
         old: [6, 4, 2, 0]
@@ -172,7 +72,7 @@ defmodule Legacy.CallsTest do
 
   describe "Legacy.Calls.aggregate" do
     test "returns a summed aggregate of the past year by default", %{now: now} do
-      assert Legacy.Calls.aggregate("call-16", from: now) == %{
+      assert Legacy.Calls.aggregate("call-2", from: now) == %{
         ts: [Utils.GranularTime.base_ts(now - 31536000)],
         new: [26],
         old: [28]
@@ -180,7 +80,7 @@ defmodule Legacy.CallsTest do
     end
 
     test "returns the requested number of periods", %{now: now} do
-      assert Legacy.Calls.aggregate("call-16", from: now, periods: 3) == %{
+      assert Legacy.Calls.aggregate("call-2", from: now, periods: 3) == %{
         ts: Utils.GranularTime.periodic_ts(now, 3, :year),
         new: [0, 0, 26],
         old: [0, 0, 28]
@@ -188,7 +88,7 @@ defmodule Legacy.CallsTest do
     end
 
     test "returns one period of the given period_size, summed", %{now: now} do
-      assert Legacy.Calls.aggregate("call-16", from: now, period_size: 2, period_granularity: :day) == %{
+      assert Legacy.Calls.aggregate("call-2", from: now, period_size: 2, period_granularity: :day) == %{
         ts: [Utils.GranularTime.base_ts(now - 86400)],
         new: [7],
         old: [8]
@@ -196,7 +96,7 @@ defmodule Legacy.CallsTest do
     end
 
     test "combines periods and period_size", %{now: now} do
-      assert Legacy.Calls.aggregate("call-16", from: now, periods: 2) == %{
+      assert Legacy.Calls.aggregate("call-2", from: now, periods: 2) == %{
         ts: [Utils.GranularTime.base_ts(now - 2*31536000), Utils.GranularTime.base_ts(now - 31536000)],
         new: [0, 26],
         old: [0, 28]
@@ -204,7 +104,7 @@ defmodule Legacy.CallsTest do
     end
 
     test "takes weeks", %{now: now} do
-      assert Legacy.Calls.aggregate("call-16", from: now, periods: 2, period_size: 5, period_granularity: :week) == %{
+      assert Legacy.Calls.aggregate("call-2", from: now, periods: 2, period_size: 5, period_granularity: :week) == %{
         ts: Utils.GranularTime.periodic_ts(now, 2, {5, :week}),
         new: [7, 19],
         old: [5, 23]
@@ -213,7 +113,7 @@ defmodule Legacy.CallsTest do
 
     test "returns averages", %{now: now} do
       assert Legacy.Calls.aggregate(
-        "call-16",
+        "call-2",
         from: now,
         periods: 2,
         period_granularity: :month,
@@ -228,14 +128,14 @@ defmodule Legacy.CallsTest do
 
   describe "Legacy.Calls.analyse" do
     test "returns last year's new rate by default", %{now: now} do
-      assert Legacy.Calls.analyse("call-16", from: now) == %{
+      assert Legacy.Calls.analyse("call-2", from: now) == %{
         ts: [Utils.GranularTime.base_ts(now - 31536000)],
         analysis: [26 / 54]
       }
     end
 
     test "supports the same options as `aggregate`", %{now: now} do
-      assert Legacy.Calls.analyse("call-16", from: now, periods: 3, period_granularity: :month) == %{
+      assert Legacy.Calls.analyse("call-2", from: now, periods: 3, period_granularity: :month) == %{
         ts: (for n <- (3..1), do: Utils.GranularTime.base_ts(now - n * 2592000)),
         analysis: [7 / 12, 7 / 15, 12 / 27]
       }
@@ -243,7 +143,7 @@ defmodule Legacy.CallsTest do
 
     test "can return a diff analysis", %{now: now} do
       assert Legacy.Calls.analyse(
-        "call-16",
+        "call-2",
         from: now,
         periods: 6,
         period_size: 2,

--- a/test/legacy/features/store_test.exs
+++ b/test/legacy/features/store_test.exs
@@ -1,0 +1,76 @@
+defmodule Legacy.Features.Store.StoreTest do
+  use Legacy.RedisCase, async: true
+  import Legacy.ExtraAsserts
+
+  describe "Legacy.Features.Store.update/2" do
+    test "sets the given values on a new feature", %{redis: redis} do
+      Legacy.Features.Store.update "feat-store-1", description: "something-else", expire_period: "12"
+
+      assert Redix.command!(redis, ~w(HGETALL features:feat-store-1)) ==
+        ["description", "something-else", "expire_period", "12"]
+    end
+
+    test "updates the given values in an existing feature", %{redis: redis} do
+      Redix.command! redis, ~w(HMSET features:feat-store-2 description something name else)
+
+      Legacy.Features.Store.update "feat-store-2", description: "something-else", expire_period: "12"
+
+      assert Redix.command!(redis, ~w(HMGET features:feat-store-2 name description expire_period)) ==
+        ["else", "something-else", "12"]
+    end
+
+    test "handles values with spaces", %{redis: redis} do
+      Legacy.Features.Store.update "feat-store-8", description: "something else"
+      assert Redix.command!(redis, ~w(HGET features:feat-store-8 description)) == "something else"
+    end
+  end
+
+  describe "Legacy.Features.Store.exists/1" do
+    test "returns true if a feature exists" do
+      Legacy.Features.init "feat-store-3"
+      assert Legacy.Features.Store.exists("feat-store-3") == true
+    end
+
+    test "returns false if a feature doesn't exist" do
+      assert Legacy.Features.Store.exists("feat-store-4") == false
+    end
+  end
+
+  describe "Legacy.Features.Store.show/1" do
+    test "returns nil when the feature does not exist" do
+      assert Legacy.Features.Store.show("feat-store-4") == nil
+    end
+
+    test "returns an initialized Feature record with the feature's attributes" do
+      Legacy.Features.init "feat-store-5"
+      feature = Legacy.Features.Store.show("feat-store-5")
+
+      assert feature[:description] == "feat-store-5"
+      assert feature[:expire_period] == 30
+      assert_date_approx feature[:created_at], DateTime.utc_now
+      assert_date_approx feature[:updated_at], DateTime.utc_now
+    end
+  end
+
+  describe "Legacy.Features.Store.set_missing/2" do
+    test "sets all the given values for a non-existing feature", %{redis: redis} do
+      Legacy.Features.Store.set_missing("feat-store-6", description: "a-feat", expire_period: 30)
+      assert Redix.command!(redis, ~w(HGETALL features:feat-store-6)) ==
+        ["description", "a-feat", "expire_period", "30"]
+    end
+
+    test "sets only the given values when they're not set", %{redis: redis} do
+      Redix.command! redis, ~w(HMSET features:feat-store-7 description a-feat name else)
+
+      Legacy.Features.Store.set_missing("feat-store-7", name: "this-name!", expire_period: 30)
+
+      assert Redix.command!(redis, ~w(HGETALL features:feat-store-7)) ==
+        ["description", "a-feat", "name", "else", "expire_period", "30"]
+    end
+
+    test "handles values with spaces", %{redis: redis} do
+      Legacy.Features.Store.set_missing("feat-store-9", description: "a feat")
+      assert Redix.command!(redis, ~w(HGET features:feat-store-9 description)) == "a feat"
+    end
+  end
+end

--- a/test/legacy/features_test.exs
+++ b/test/legacy/features_test.exs
@@ -1,5 +1,4 @@
 defmodule Legacy.FeaturesTest do
-  import Legacy.ExtraAsserts
   use Legacy.RedisCase, async: true
 
   describe "Legacy.Features.init/1" do
@@ -50,51 +49,6 @@ defmodule Legacy.FeaturesTest do
       Legacy.Features.init "ft-feat-4", description: "something-else"
 
       assert Redix.command!(redis, ~w(HGET features:ft-feat-4 description)) == "something-else"
-    end
-  end
-
-  describe "Legacy.Features.update/2" do
-    test "sets the given values on a new feature", %{redis: redis} do
-      Legacy.Features.update "ft-feat-5", description: "something-else", expire_period: "12"
-
-      assert Redix.command!(redis, ~w(HGETALL features:ft-feat-5)) ==
-        ["description", "something-else", "expire_period", "12"]
-    end
-
-    test "updates the given values in an existing feature", %{redis: redis} do
-      Redix.command! redis, ~w(HMSET features:ft-feat-6 description something name else)
-
-      Legacy.Features.update "ft-feat-6", description: "something-else", expire_period: "12"
-
-      assert Redix.command!(redis, ~w(HMGET features:ft-feat-6 name description expire_period)) ==
-        ["else", "something-else", "12"]
-    end
-  end
-
-  describe "Legacy.Features.exists/1" do
-    test "returns true if a feature exists" do
-      Legacy.Features.init "ft-feat-7"
-      assert Legacy.Features.exists("ft-feat-7") == true
-    end
-
-    test "returns false if a feature doesn't exist" do
-      assert Legacy.Features.exists("ft-feat-8") == false
-    end
-  end
-
-  describe "Legacy.Features.show/1" do
-    test "returns nil when the feature does not exist" do
-      assert Legacy.Features.show("ft-test-8") == nil
-    end
-
-    test "returns an initialized Feature record with the feature's attributes" do
-      Legacy.Features.init "ft-feat-9"
-      feature = Legacy.Features.show("ft-feat-9")
-
-      assert feature[:description] == "ft-feat-9"
-      assert feature[:expire_period] == 30
-      assert_date_approx feature[:created_at], DateTime.utc_now
-      assert_date_approx feature[:updated_at], DateTime.utc_now
     end
   end
 end


### PR DESCRIPTION
Separates functions that communicate with the Feature and Call datastore (redis) into their own separate module. This makes a few of them unit testable and simplifies code a bit.

Changes `get_many` return to match `get` (list of tuples instead of list of lists).

Adds a few aliases to make things neater. Adds some more typespecs.